### PR TITLE
Remove Danger references across all teams

### DIFF
--- a/docs/teams/android/development/00_git_flow.md
+++ b/docs/teams/android/development/00_git_flow.md
@@ -87,7 +87,7 @@ In general, the PR description is optional. If you want to help your colleagues 
 
 ### PR Check
 
-Our pull requests are automatically checked by GitHub Actions to ensure code quality and convention standards. If the PR does not comply with the rules, Danger will report the issues as a comment on the related PR, so the shortcomings can be fixed.
+Our pull requests are automatically checked by GitHub Actions to ensure code quality and convention standards.
 
 
 

--- a/docs/teams/android/development/10_code_style.md
+++ b/docs/teams/android/development/10_code_style.md
@@ -47,15 +47,9 @@ The config file is located at `config/detekt.yml`.
 
 Link to [current config](https://github.com/futuredapp/kmp-futured-template/blob/develop/config/detekt.yml)
 
-### Danger
-
-[Danger](https://danger.systems/) provides an easier way to craft Continuous Integration scripts. It runs during your CI, and automates common code review chores, hence providing additional continuous integration and enforcement of specific standards before merging any code.
-
-Each repository should have its own `Dangerfile`, adapted to specific needs. We also apply company-wide [danger rules](https://github.com/futuredapp/danger) across all our projects. The `Dangerfile` refers to these rules.
-
 ## How to be a good developer
 
 1. Set your Android Studio code style to the default settings - let `.editorconfig` define your IDE's formatting style.
 2. Either install the KtLint IDEA plugin or run the `ktLintFormat` gradle task before making a commit.
 3. When you are ready to create a PR, ensure you run the `lintCheck` gradle task first and fix any reported issues to keep the codebase clean.
-4. During a PR check, the `lintCheck` gradle task is run again to catch any remaining issues, which are then reported by Danger.
+4. During a PR check, the `lintCheck` gradle task is run again to catch any remaining issues.

--- a/docs/teams/fullstack/development/00_git_flow.md
+++ b/docs/teams/fullstack/development/00_git_flow.md
@@ -53,11 +53,6 @@ We use a structured Git branching model to ensure smooth collaboration and maint
 
 
 
-### Automated Checks
-
-- **Dangerfile**  
-  We use a Dangerfile to automatically check commit and pull request parameters, ensuring adherence to our standards.
-
 ### Release Tags
 
 - **Version Tags**  

--- a/docs/teams/fullstack/development/20_code_review_process.md
+++ b/docs/teams/fullstack/development/20_code_review_process.md
@@ -6,7 +6,7 @@ A thorough code review process helps us maintain high quality, consistency, and 
   Every pull request must receive at least one approving review before it can be merged.
 
 - **Passing Checks**  
-  All automated PR checks (CI, Dangerfile, tests, etc.) must pass before merging.
+  All automated PR checks (CI, tests, etc.) must pass before merging.
 
 - **Draft PRs**  
   Draft pull requests are welcome for early feedback, but they are not reviewed until marked as "Ready for Review."

--- a/docs/teams/ios/ios_git_flow.md
+++ b/docs/teams/ios/ios_git_flow.md
@@ -53,6 +53,4 @@ While doing code review, be nice and respect the work of another team member. Pa
 
 ### Continuous Integration
 
-Another required part to merge a PR is successful build on the CI. Pull request with failing build is not possible to merge. CI also sends [Danger](http://danger.systems/ruby/) report to the PR, which checks both git flow rules enforcements and code style issues. Danger rules in use on our projects are available in [futuredapp/danger]( https://github.com/futuredapp/danger/) repository.
-
-Danger reports issues and errors. Errors must be fixed before merging the PR, issues are strongly recommended to fix.
+Another required part to merge a PR is successful build on the CI. Pull request with failing build is not possible to merge.

--- a/docs/teams/ios/ios_new_project.md
+++ b/docs/teams/ios/ios_new_project.md
@@ -276,14 +276,6 @@
             - add `test/test` check (for GitHub Actions)
             
             ![Step 16](Resources/ios_new_project_27.png){ width="900" }
-            
-            - add `danger/danger` check (for Any source)
-            
-            ![Step 17](Resources/ios_new_project_28.png){ width="200" }
-            
-            - added checks looks like this
-            
-            ![Step 18](Resources/ios_new_project_29.png){ width="500" }
 
 6. Enjoy!
 


### PR DESCRIPTION
- Odstranění všech zmínek o Dangeru z dokumentace iOS, Android a Fullstack týmů
- Danger byl v únoru 2026 ukončen a repo `futuredapp/danger` archivováno