### PR TITLE
docs(ios): note Account Holder requirement for first API access request

### DIFF
--- a/docs/teams/ios/ios_customer_account.md
+++ b/docs/teams/ios/ios_customer_account.md
@@ -72,6 +72,10 @@ To establish our CI flow and be able to deliver builds to customer's App Store C
             ??? info "First App Store Connect API usage"
             
                 In case you haven't granted App Store Connect API permission yet:
+
+                !!! warning "Account Holder required"
+
+                    Only the customer's `Account Holder` can request access the first time. Once access is granted, `Admin` role is enough to create further keys - see [Role permissions](https://developer.apple.com/help/app-store-connect/reference/account-management/role-permissions/).
         
                 - click `Request Access` button
         

--- a/docs/teams/ios/ios_customer_account.md
+++ b/docs/teams/ios/ios_customer_account.md
@@ -105,11 +105,7 @@ To establish our CI flow and be able to deliver builds to customer's App Store C
                 ![Step 6](Resources/ios_customer_account_9.png){ width="500" }
                 
         - add customer's App Store Connect API key to project's repo secrets
-
-            !!! tip "Prefer environment-scoped secrets"
-
-                Instead of plain repository secrets, add these as secrets on a GitHub `production` environment with a deployment branch rule limited to `main`. This way the key is only readable by workflow runs triggered from `main`, not from any branch/PR.
-
+        
             - go to your project GitHub repo
 
                 ![Step 7](Resources/ios_customer_account_10.png){ width="900" }
@@ -117,10 +113,6 @@ To establish our CI flow and be able to deliver builds to customer's App Store C
                 1. open `Settings` (you need repo admin role to see `Settings` option)
                 2. select `Secrets and variables` section and `Actions` subsection
                 3. click `New repository secret` button
-
-                !!! tip "Environment secrets instead"
-
-                    To restrict the secrets to `main` only, go to `Settings` → `Environments` instead, create/select the `production` environment, under `Deployment branches and tags` set the rule to `Selected branches and tags` → `main`, then add the secrets there and reference the `production` environment in the CI workflow job.
             
             - add following secrets (keep naming!):
                 - `APP_STORE_CONNECT_API_KEY_ISSUER_ID_CUSTOMER` = `Issuer ID`

--- a/docs/teams/ios/ios_customer_account.md
+++ b/docs/teams/ios/ios_customer_account.md
@@ -105,7 +105,11 @@ To establish our CI flow and be able to deliver builds to customer's App Store C
                 ![Step 6](Resources/ios_customer_account_9.png){ width="500" }
                 
         - add customer's App Store Connect API key to project's repo secrets
-        
+
+            !!! tip "Prefer environment-scoped secrets"
+
+                Instead of plain repository secrets, add these as secrets on a GitHub `production` environment with a deployment branch rule limited to `main`. This way the key is only readable by workflow runs triggered from `main`, not from any branch/PR.
+
             - go to your project GitHub repo
 
                 ![Step 7](Resources/ios_customer_account_10.png){ width="900" }
@@ -113,6 +117,10 @@ To establish our CI flow and be able to deliver builds to customer's App Store C
                 1. open `Settings` (you need repo admin role to see `Settings` option)
                 2. select `Secrets and variables` section and `Actions` subsection
                 3. click `New repository secret` button
+
+                !!! tip "Environment secrets instead"
+
+                    To restrict the secrets to `main` only, go to `Settings` → `Environments` instead, create/select the `production` environment, under `Deployment branches and tags` set the rule to `Selected branches and tags` → `main`, then add the secrets there and reference the `production` environment in the CI workflow job.
             
             - add following secrets (keep naming!):
                 - `APP_STORE_CONNECT_API_KEY_ISSUER_ID_CUSTOMER` = `Issuer ID`


### PR DESCRIPTION
## Summary
- Clarifies in `ios_customer_account.md` that only the customer's `Account Holder` can request App Store Connect API access the first time; `Admin` is enough for subsequent keys.

## Test plan
- Docs-only change, rendered with MkDocs admonitions consistent with the rest of the file.